### PR TITLE
Reuse section object in get_dupes

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -50,8 +50,14 @@ except:
 
 
 def get_dupes(plex_section_name):
-    sec_type = get_section_type(plex_section_name)
-    dupe_search_results = plex.library.section(plex_section_name).search(duplicate=True, libtype=sec_type)
+    try:
+        plex_section = plex.library.section(plex_section_name)
+        sec_type = 'episode' if plex_section.type == 'show' else 'movie'
+    except Exception:
+        log.exception("Exception occurred while trying to lookup the section type for Library: %s", plex_section_name)
+        exit(1)
+
+    dupe_search_results = plex_section.search(duplicate=True, libtype=sec_type)
 
     dupe_search_results_new = dupe_search_results.copy()
     if cfg['FIND_DUPLICATE_FILEPATHS_ONLY']:
@@ -59,15 +65,6 @@ def get_dupes(plex_section_name):
             if any(x != dupe.locations[0] for x in dupe.locations):
                 dupe_search_results_new.remove(dupe)
     return dupe_search_results_new
-
-
-def get_section_type(plex_section_name):
-    try:
-        plex_section_type = plex.library.section(plex_section_name).type
-    except Exception:
-        log.exception("Exception occurred while trying to lookup the section type for Library: %s", plex_section_name)
-        exit(1)
-    return 'episode' if plex_section_type == 'show' else 'movie'
 
 
 def get_score(media_info):


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6a2eefa7-edcc-4c63-9b15-ef0a51b6c66d","source":"chat","resourceId":"112cb4d2-95d6-4a0d-a2bb-ca42b1733618","workflowId":"018f86f6-76bd-43b7-a315-c7dc229233ee","codeChangeId":"018f86f6-76bd-43b7-a315-c7dc229233ee","sourceType":"trace"} -->
## Summary

Trace Investigation • [View in Trace Investigation](https://app.datadoghq.com/apm/trace/69b67a21000000008aed2f825df5efca?spanID=3101914453521638785&trace-assistant-investigation-id=72cc31a5-2830-4214-8ae6-3799d6f38b93&trace-assistant-panel-open=true)

This change reduces avoidable latency in duplicate scanning by removing a redundant Plex section lookup in `get_dupes`. The trace investigation (trace_id `69b67a21000000008aed2f825df5efca`) showed duplicate metadata requests for the same section.

## Changes
- Updated `get_dupes` in `plex_dupefinder.py` to call `plex.library.section(plex_section_name)` once and reuse the returned section object.
- Inlined section type resolution into `get_dupes` (`show` -> `episode`, otherwise `movie`) using the reused section object.
- Preserved the existing error handling behavior (same `try/except`, logging message, and `exit(1)`) for section lookup/type resolution failures.
- Switched duplicate search to `plex_section.search(...)`.
- Removed the now-unused `get_section_type` function.

## Testing
- `python -m py_compile plex_dupefinder.py config.py` (successful; emitted an existing `SyntaxWarning` in the ASCII-art banner string at line 324).
- Ran `Format` tool (no formatter auto-detected for `plex_dupefinder.py`).
- Ran `Lint` tool (no linter auto-detected for `plex_dupefinder.py`).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/112cb4d2-95d6-4a0d-a2bb-ca42b1733618)