### PR TITLE
Parallelize duplicate section processing

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import collections
+import concurrent.futures
 import itertools
 import logging
 import os
@@ -316,6 +317,32 @@ def build_tabulated(parts, items):
     return headers, part_data
 
 
+def process_section(section):
+    dupes = get_dupes(section)
+    section_results = {}
+    for item in dupes:
+        if item.type == 'episode':
+            title = "%s - %02dx%02d - %s" % (
+                item.grandparentTitle, int(item.parentIndex), int(item.index), item.title)
+        elif item.type == 'movie':
+            title = item.title
+        else:
+            title = 'Unknown'
+
+        log.info("Processing: %r", title)
+        parts = {}
+        for part in item.media:
+            part_info = get_media_info(part)
+            if not cfg['FIND_DUPLICATE_FILEPATHS_ONLY']:
+                part_info['score'] = get_score(part_info)
+            part_info['show_key'] = item.key
+            log.info("ID: %r - Score: %s - Meta:\n%r", part.id, part_info.get('score', 'N/A'),
+                     part_info)
+            parts[part.id] = part_info
+        section_results[title] = parts
+    return section, len(dupes), section_results
+
+
 ############################################################
 # MAIN
 ############################################################
@@ -342,31 +369,19 @@ if __name__ == "__main__":
     process_later = {}
     # process sections
     print("Finding dupes...")
-    for section in cfg['PLEX_LIBRARIES']:
-        dupes = get_dupes(section)
-        print("Found %d dupes for section %r" % (len(dupes), section))
-        # loop returned duplicates
-        for item in dupes:
-            if item.type == 'episode':
-                title = "%s - %02dx%02d - %s" % (
-                    item.grandparentTitle, int(item.parentIndex), int(item.index), item.title)
-            elif item.type == 'movie':
-                title = item.title
-            else:
-                title = 'Unknown'
+    completed_sections = [None] * len(cfg['PLEX_LIBRARIES'])
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, len(cfg['PLEX_LIBRARIES']))) as executor:
+        futures = {
+            executor.submit(process_section, section): idx
+            for idx, section in enumerate(cfg['PLEX_LIBRARIES'])
+        }
+        for future in concurrent.futures.as_completed(futures):
+            completed_sections[futures[future]] = future.result()
 
-            log.info("Processing: %r", title)
-            # loop returned parts for media item (copy 1, copy 2...)
-            parts = {}
-            for part in item.media:
-                part_info = get_media_info(part)
-                if not cfg['FIND_DUPLICATE_FILEPATHS_ONLY']:
-                    part_info['score'] = get_score(part_info)
-                part_info['show_key'] = item.key
-                log.info("ID: %r - Score: %s - Meta:\n%r", part.id, part_info.get('score', 'N/A'),
-                         part_info)
-                parts[part.id] = part_info
-            process_later[title] = parts
+    for section_result in completed_sections:
+        section, dupe_count, section_items = section_result
+        print("Found %d dupes for section %r" % (dupe_count, section))
+        process_later.update(section_items)
 
     # process processed items
     time.sleep(5)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6b309634-1d44-480a-a68d-544cffa13c45","source":"chat","resourceId":"dcce7fb7-cb49-4bad-ae0d-490fa9f51535","workflowId":"4f1a6b18-44c9-4908-83a7-7c549e335e7a","codeChangeId":"4f1a6b18-44c9-4908-83a7-7c549e335e7a","sourceType":"trace"} -->
## Summary

Trace Investigation • [View in Trace Investigation](https://app.datadoghq.com/apm/trace/69b67a21000000008aed2f825df5efca?spanID=3101914453521638785&trace-assistant-investigation-id=72cc31a5-2830-4214-8ae6-3799d6f38b93&trace-assistant-panel-open=true)

Parallelize duplicate discovery across Plex library sections to reduce total wall-clock latency when multiple libraries are configured.

## Changes
- Added `concurrent.futures` import in `plex_dupefinder.py`.
- Added a new `process_section(section)` helper that performs per-section work (`get_dupes`, duplicate item iteration, media scoring/info extraction) and returns section-local results.
- Replaced the sequential loop over `cfg['PLEX_LIBRARIES']` with a `ThreadPoolExecutor` fan-out/fan-in flow:
  - submit one worker per configured section,
  - collect completed futures,
  - merge results into `process_later` on the main thread.
- Kept merge behavior thread-safe by avoiding shared mutable writes from worker threads; workers build local dictionaries and only the main thread updates `process_later`.

## Testing
- `python -m py_compile plex_dupefinder.py` (passes; emits a pre-existing `SyntaxWarning` from ASCII-art string escaping)
- `Format` tool (no formatter auto-detected for this repo/file)
- `Lint` tool (no linter auto-detected for this repo/file)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/dcce7fb7-cb49-4bad-ae0d-490fa9f51535)