### PR TITLE
Optimize duplicate filepath filtering

### DIFF
--- a/plex_dupefinder.py
+++ b/plex_dupefinder.py
@@ -53,12 +53,10 @@ def get_dupes(plex_section_name):
     sec_type = get_section_type(plex_section_name)
     dupe_search_results = plex.library.section(plex_section_name).search(duplicate=True, libtype=sec_type)
 
-    dupe_search_results_new = dupe_search_results.copy()
-    if cfg['FIND_DUPLICATE_FILEPATHS_ONLY']:
-        for dupe in dupe_search_results:
-            if any(x != dupe.locations[0] for x in dupe.locations):
-                dupe_search_results_new.remove(dupe)
-    return dupe_search_results_new
+    if not cfg['FIND_DUPLICATE_FILEPATHS_ONLY']:
+        return dupe_search_results
+
+    return [dupe for dupe in dupe_search_results if all(location == dupe.locations[0] for location in dupe.locations)]
 
 
 def get_section_type(plex_section_name):


### PR DESCRIPTION
<!-- dd-meta {"pullId":"eb23f1b3-385b-45d2-92ed-26205cec9ed0","source":"chat","resourceId":"7aa5e8d4-5fbb-4ce1-8d3e-ff4e01ee6bb9","workflowId":"f93ee238-ee2d-4edf-bec8-332a2d285dc5","codeChangeId":"f93ee238-ee2d-4edf-bec8-332a2d285dc5","sourceType":"trace"} -->
## Summary

Trace Investigation • [View in Trace Investigation](https://app.datadoghq.com/apm/trace/69b67a21000000008aed2f825df5efca?spanID=3101914453521638785&trace-assistant-investigation-id=72cc31a5-2830-4214-8ae6-3799d6f38b93&trace-assistant-panel-open=true)

This change optimizes duplicate filtering in `get_dupes` to avoid quadratic behavior when `FIND_DUPLICATE_FILEPATHS_ONLY` is enabled.

## Changes
- Updated `plex_dupefinder.py` in `get_dupes` to return `dupe_search_results` directly when `FIND_DUPLICATE_FILEPATHS_ONLY` is disabled.
- Replaced copy-and-remove filtering logic with a single-pass list comprehension when `FIND_DUPLICATE_FILEPATHS_ONLY` is enabled.
- Preserved behavior by keeping only duplicate items where all `dupe.locations` match `dupe.locations[0]`.

## Testing
- Ran `python -m py_compile plex_dupefinder.py` (completed successfully; pre-existing SyntaxWarning from ASCII banner remains).
- Ran automated `Format` tool (no formatter detected for this file).
- Ran automated `Lint` tool (no linter detected for this file).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7aa5e8d4-5fbb-4ce1-8d3e-ff4e01ee6bb9)